### PR TITLE
Add MIT licensing terms where missing

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+The MIT License (MIT)
+=====================
+
+Copyright © `2015` `P. Guardiario <pguardiario@gmail.com>`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pguardiario/phpuri",
 	"type": "project",
-	"version": "1.0",
+	"license": "MIT",
     "description": "A php library for converting relative urls to absolute.",
 	"autoload" : {
 		"files": [

--- a/test.php
+++ b/test.php
@@ -1,5 +1,21 @@
 <?php
 
+  /**
+   * A php library for converting relative urls to absolute.
+   * Website: https://github.com/monkeysuffrage/phpuri
+   *
+   * <pre>
+   * echo phpUri::parse('https://www.google.com/')->join('foo');
+   * //==> https://www.google.com/foo
+   * </pre>
+   *
+   * Licensed under The MIT License
+   * Redistributions of files must retain the above copyright notice.
+   *
+   * @author  P Guardiario <pguardiario@gmail.com>
+   * @version 1.0
+   */
+
 require('../rel2abs.php');
 require('../url_to_absolute.php');
 require('phpuri.php');


### PR DESCRIPTION
Hi,

I've added licensing terms where they were missing. Also I've removed the explicit "version" element from the `composer.json` file since composer automatically infers version numbers from the VCS information.
