### PR TITLE
Sanitize trailing slash problem for path

### DIFF
--- a/phpuri.php
+++ b/phpuri.php
@@ -67,6 +67,16 @@
 			 * With the former code, the relative urls //g and #s failed
 			 */
 			$this->path     = $m[ 5 ][ 0 ];
+			/**
+			* CHANGE:
+			* @author ulrischa
+			* Sanitize trailing slash problem
+			**/
+			//Is not file?
+			$re = '`/([^/.]+)$`m';
+			$subst = '/$1/';
+			$this->path = preg_replace($re, $subst, $this->path);
+
 			$this->query    = $m[ 7 ][ 0 ];
 			$this->fragment = $m[ 9 ][ 0 ];
 		}


### PR DESCRIPTION
phpUri::parse('https://www.google.com/dir1/dir2/dir3')->join('../../foo.jpg'); causes an error in the path. The reason is the missing trailing slash in the url given in parse(). This fixes the problem by appending the slash if it's missing directly in the constructor